### PR TITLE
TypeError: arr[i][currKey].toLowerCase is not a function.

### DIFF
--- a/main.js
+++ b/main.js
@@ -205,7 +205,7 @@ const findFromDataBaseSync = (name, dir, keys, value) => {
 		for (var i = 0; i < arr.length; i++) {
 			for (var j = 0; j < keys.length; j++) {
 				let currKey = keys[j]
-				if (arr[i][currKey] != null && arr[i][currKey] != undefined) {
+				if (typeof arr[i][currKey] === 'string' && arr[i][currKey] !== null) {
 					let start = arr[i][currKey].toLowerCase().indexOf(value.toLowerCase());
 					if (start !== -1) {
 						if (i > 0 ){


### PR DESCRIPTION
If the value of the key I want to call is not a string, it gives an type error.
Because toLowerCase() is a string prototype.

The problem was solved by checking the type.